### PR TITLE
fix: Resolve SSH authentication error in docs build workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          pip install .
           pip install -r requirements.txt
           pip install mkdocs mkdocs-material mkdocstrings mkdocstrings-python
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,6 @@ gpg==1.15.1
 grpcio==1.60.1
 gssapi==1.6.9
 gunicorn==21.2.0
--e git+ssh://git@github.com/thapecroth/gym2vid.git@4d14a3f24d486695c817be24bd8b0734d24404c1#egg=gym2vid
 gymnasium==1.1.1
 h11==0.8.1
 h2==3.2.0


### PR DESCRIPTION
The GitHub Actions workflow for building documentation was failing due to an SSH authentication error. This was caused by a line in `requirements.txt` that attempted to install the `gym2vid` package itself from a specific commit using an SSH Git URL: `-e git+ssh://git@github.com/thapecroth/gym2vid.git@...`

This commit addresses the issue by:
1. Removing the problematic self-referential line from `requirements.txt`. The project itself should be installed via `setup.py`.
2. Modifying the `.github/workflows/docs.yml` to first install the project using `pip install .` and then install other dependencies from `requirements.txt` and the necessary MkDocs packages.

This ensures that the package is built from the local source and that dependencies are installed correctly within the GitHub Actions runner environment, resolving the authentication error.